### PR TITLE
Update ThinkOrm.php

### DIFF
--- a/src/ThinkOrm.php
+++ b/src/ThinkOrm.php
@@ -29,10 +29,15 @@ class ThinkOrm implements Bootstrap
                 $manager_instance = $property->getValue();
             }
             Timer::add(55, function () use ($manager_instance) {
-                $reflect = new \ReflectionClass($manager_instance);
-                $property = $reflect->getProperty('instance');
-                $property->setAccessible(true);
-                $instances  = $property->getValue($manager_instance);
+                $instances = [];
+                if (method_exists($manager_instance, 'getInstance')) {
+                    $instances = $manager_instance->getInstance();
+                } else {
+                    $reflect = new \ReflectionClass($manager_instance);
+                    $property = $reflect->getProperty('instance');
+                    $property->setAccessible(true);
+                    $instances = $property->getValue($manager_instance);
+                }
                 foreach ($instances as $connection) {
                     /* @var \think\db\connector\Mysql $connection */
                     if ($connection->getConfig('type') == 'mysql') {


### PR DESCRIPTION
给`DbManager`增加`getInstance`方法获取所有连接实列，就可以不用反射的方式。
https://github.com/top-think/think-orm/commit/91693ac4ee20f3d24d1ec8656aa411d041e37d64