### PR TITLE
将query和execute改为静态方法，以便可以使用DB::query和DB::execute调用

### DIFF
--- a/src/_ide_helper.php
+++ b/src/_ide_helper.php
@@ -82,7 +82,7 @@ namespace think\facade {
          * @throws \think\db\exception\BindParamException
          * @throws \PDOException
          */
-        public function query(string $sql, array $bind = []): array
+        public static function query(string $sql, array $bind = []): array
         {
             /** @var \think\Db $instance */
             return $instance->query($sql,$bind);
@@ -108,7 +108,7 @@ namespace think\facade {
          * @throws \think\db\exception\BindParamException
          * @throws \PDOException
          */
-        public function execute(string $sql, array $bind = []): int
+        public static function execute(string $sql, array $bind = []): int
         {
             /** @var \think\Db $instance */
             return $instance->execute($sql,$bind);


### PR DESCRIPTION
当使用DB::query和DB::execute的时候，编辑器报异常，将query和execute改为静态方法即可。