### PR TITLE
surpport think-orm 4.0.x-dev

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
   "type": "library",
   "license": "MIT",
   "require": {
-    "topthink/think-orm": "^2.0.53 || ^3.0.0"
+    "topthink/think-orm": "^2.0.53 || ^3.0.0 || ^4.0.0"
   },
   "autoload": {
     "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
   "type": "library",
   "license": "MIT",
   "require": {
-    "topthink/think-orm": "^2.0.53 || ^3.0.0 || ^4.0.0"
+    "topthink/think-orm": "^2.0.53 || ^3.0.0 || ^4.* || 4.*"
   },
   "autoload": {
     "psr-4": {


### PR DESCRIPTION
php8.3 等强类型的 类里返回值 类型 和arrayAccess 不匹配 需要4.0 dev版本来修复