### PR TITLE
fix: 修复 DbManager::instance 类型错误

### DIFF
--- a/src/DbManager.php
+++ b/src/DbManager.php
@@ -34,7 +34,7 @@ class DbManager extends \think\DbManager
      * @return ConnectionInterface
      * @throws Throwable
      */
-    protected function instance(?string $name = null, bool $force = false): ConnectionInterface
+    protected function instance(array|string|null $name = null, bool $force = false): ConnectionInterface
     {
         if (empty($name)) {
             $name = $this->getConfig('default', 'mysql');


### PR DESCRIPTION
新拉取的 webman 使用 think-orm 插件的时候，会报如下错误
```php
Fatal error: Declaration of Webman\ThinkOrm\DbManager::instance(?string $name = null, bool $force = false): think\db\ConnectionInterface must be compatible with think\DbManager::instance(array|string|null $name = null, bool $force = false): think\db\ConnectionInterface in C:\project\catch-webman\vendor\webman\think-orm\src\DbManager.php on line 37
```